### PR TITLE
Normalize flag size

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+__tests__
+examples
+babel.config.js
+react-native-flags-kit.png

--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ You can find the source code [here](./examples/FlagsKitBasic).
 |:----------|:----------|:----------|:----------|
 | code | string | | [The ISO code of a flag](https://www.translatorscafe.com/cafe/ISO-3166-Country-Codes.htm), for example "KH", "US" or "GB". |
 | type | string (flat or shiny) | shiny | Display the flags shiny or flat. |
-| size | number (16, 24, 32, 48 or 64) | 64 | The size of a flag in points (Note: Setting a size of any other values will cause and error). |
-| style (optional) |  |  | Allows additional styles to be passed through. |
+| size | number (16, 24, 32, 48 or 64) | 64 | The size of a flag in points (Note: Setting a different size will render the closest one - e.g. `17 -> 16`, `29 -> 32`). |
+| style (optional) |  |  | Allows additional `Image` styles to be passed through. |
 
 ## Wrap Up
 

--- a/__tests__/utils.js
+++ b/__tests__/utils.js
@@ -1,0 +1,25 @@
+const utils = require("../src/utils");
+
+test("should find best size, when greater", () => {
+  expect(utils.findBestSize(17)).toBe(16);
+});
+
+test("should find best size, when equal", () => {
+  expect(utils.findBestSize(24)).toBe(24);
+});
+
+test("should find best size, when lower", () => {
+  expect(utils.findBestSize(29)).toBe(32);
+});
+
+test("should find best size, when higher than max size", () => {
+  expect(utils.findBestSize(70)).toBe(64);
+});
+
+test("should handle null input", () => {
+  expect(utils.findBestSize(null)).toBe(64);
+});
+
+test("should handle undefined input", () => {
+  expect(utils.findBestSize()).toBe(64);
+});

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,13 @@
+// babel.config.js
+module.exports = {
+  presets: [
+    [
+      '@babel/preset-env',
+      {
+        targets: {
+          node: 'current',
+        },
+      },
+    ],
+  ],
+};

--- a/index.js
+++ b/index.js
@@ -3,25 +3,30 @@ import PropTypes from 'prop-types';
 import { Image } from 'react-native';
 import * as flags from './src';
 
-const Flag = props => {
-  const flag = flags[props.type][`icons${props.size}`][props.code];
-  const unknownFlag = flags[props.type][`icons${props.size}`]['unknown'];
+const Flag = ({ code, size, style, type }) => {
+  const flagSize = flags.utils.findBestSize(size);
+  const flagsBucket = flags[type][`icons${flagSize}`];
+  const flag = flagsBucket[code];
+  const unknownFlag = flagsBucket['unknown'];
 
   return (
     <Image
       source={flag || unknownFlag}
-      style={[{ width: props.size, height: props.size }, props.style]}
+      style={[{ width: flagSize, height: flagSize }, style]}
     />
   );
 };
 
 Flag.propTypes = {
-  size: PropTypes.number,
-  type: PropTypes.string,
+  code: PropTypes.string.isRequired,
+  size: PropTypes.oneOf([16, 24, 32, 48, 64]),
+  style: Image.propTypes.style,
+  type: PropTypes.oneOf(["flat", "shiny"]),
 };
 
 Flag.defaultProps = {
   size: 64,
+  style: null,
   type: "shiny",
 };
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "React Native Flags Kit - React Native Flag component with all the flags in the world.",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "keywords": [
     "react-native",
@@ -31,5 +31,11 @@
     "type": "git",
     "url": "https://github.com/themodernjavascript/react-native-flags-kit.git"
   },
-  "nativePackage": true
+  "nativePackage": true,
+  "devDependencies": {
+    "@babel/core": "^7.4.5",
+    "@babel/preset-env": "^7.4.5",
+    "babel-jest": "^24.8.0",
+    "jest": "^24.8.0"
+  }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import * as flat from './icons/flat';
 import * as shiny from './icons/shiny';
+import * as utils from './utils';
 
-export { flat, shiny };
+export { flat, shiny, utils };

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,27 @@
+const supportedSizes = [16, 24, 32, 48, 64];
+
+const defaultSize = supportedSizes[4];
+
+export function findBestSize(targetSize) {
+  if (!targetSize) {
+    // Return default size
+    return defaultSize;
+  }
+
+  if (targetSize <= supportedSizes[0]) {
+    return supportedSizes[0];
+  }
+
+  if (targetSize >= supportedSizes[supportedSizes.length]) {
+    return supportedSizes[supportedSizes.length];
+  }
+
+  let i = 0;
+  let bestSize = defaultSize;
+  while (i < supportedSizes.length && (supportedSizes[i] <= targetSize || supportedSizes[i + 1] >= targetSize)) {
+    bestSize = Math.abs(supportedSizes[i] - targetSize) < Math.abs(bestSize - targetSize) ? supportedSizes[i] : bestSize;
+    i++;
+  }
+
+  return bestSize;
+}


### PR DESCRIPTION
This should be a better fix for #1 .

The updated `PropTypes` will warn the user about the wrong size supplied, but instead of throwing an error the supplied size will be interpolated to one of the acceptable ones.

Also added some tests for the newly implemented method.