### PR TITLE
Replace defaultProps with default function parameters  in components

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,26 +3,23 @@ import PropTypes from 'prop-types';
 import { Image } from 'react-native';
 import * as flags from './src';
 
-const Flag = props => {
-  const flag = flags[props.type][`icons${props.size}`][props.code];
-  const unknownFlag = flags[props.type][`icons${props.size}`]['unknown'];
+const Flag = ({ size = 64, type = "shiny", code, style }) => {
+  const flag = flags[type][`icons${size}`][code];
+  const unknownFlag = flags[type][`icons${size}`]['unknown'];
 
   return (
-    <Image
-      source={flag || unknownFlag}
-      style={[{ width: props.size, height: props.size }, props.style]}
-    />
+      <Image
+          source={flag || unknownFlag}
+          style={[{ width: size, height: size }, style]}
+      />
   );
 };
 
 Flag.propTypes = {
   size: PropTypes.number,
   type: PropTypes.string,
-};
-
-Flag.defaultProps = {
-  size: 64,
-  type: "shiny",
+  code: PropTypes.string.isRequired,
+  style: PropTypes.object,
 };
 
 export default Flag;


### PR DESCRIPTION
Description :
This PR updates the Flag component in the react-native-flags-kit library to use default function parameters instead of defaultProps. This change is made in response to React's upcoming deprecation of defaultProps in function components, ensuring that the library remains up-to-date with the latest React standards and practices.

Key Changes:

- Flag component previously using defaultProps now utilize default function parameters.

- This includes Flag component, where parameters like size and type are set to default directly within the function signature.

Related Issue:
[Replace defaultProps with Default Function Parameters in Flag Component](https://github.com/themodernjavascript/react-native-flags-kit/issues/25)